### PR TITLE
feat: removed "events" dependency

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,64 @@
+export declare const PerfEventType = "perf";
+/** Event triggered when performance ratio (`this.frameDuration / averageDeltaTime`) is updated. Understand a ratio of the fps, for instance for a fps value of 24, `ratio < 0.5` means that the averaged `fps < 12` and you should probably do something about it. */
+declare class PerfEvent extends Event {
+    /** The performance ratio of frame duration against average delta time. */
+    ratio: number;
+    constructor();
+}
+export declare const TickEventType = "tick";
+/** Event triggered on tick, throttled by `options.fps`. */
+declare class TickEvent extends Event {
+    /** The delta since previous frame. */
+    timeDelta: number;
+    constructor();
+}
+type RafPerfEvent = PerfEvent | TickEvent;
+
+export type OptionsPerformances = {
+    /** Evaluate performances. */
+    enabled: boolean;
+    /** Number of samples to evaluate performances. */
+    samplesCount: number;
+    /** Duration of sample to evaluate performances. */
+    sampleDuration: number;
+};
+export type Options = {
+    /** Throttle fps. */
+    fps: number;
+    /** Performances metrics. */
+    performances: OptionsPerformances;
+};
+
+/** Creates an instance of RafPerf. */
+export default class RafPerf extends EventTarget {
+    static now: () => number;
+    static fpsToMs(value: number): number;
+    static PerfEvent: PerfEvent;
+    static TickEvent: TickEvent;
+    options: Options;
+    isVisible?: boolean;
+    running?: boolean;
+    prevTime?: number | null;
+    startTime?: number | null;
+    frameDuration?: number;
+    performance?: number;
+    perfSamples?: number[];
+    requestID?: number;
+    perfStartTime?: number;
+    constructor(options?: Partial<Options>);
+    reset(): void;
+    /** Run the `requestAnimationFrame` loop and start checking performances if `options.performances.enabled` is `true`. */
+    start(): void;
+    /** The frame loop callback. Fires {@link PerfEvent} and {@link TickEvent}. */
+    tick(): void;
+    /** Run `cancelAnimationFrame` if necessary and reset the engine. */
+    stop(): void;
+    onVisibilityChange(): void;
+    dispatchEvent(e: RafPerfEvent): boolean;
+    addEventListener<T extends RafPerfEvent['type'], TEvent extends RafPerfEvent & {
+        type: T;
+    }>(type: T, listener: ((e: TEvent) => void) | EventListenerObject | null, options?: boolean | AddEventListenerOptions): void;
+    removeEventListener<T extends RafPerfEvent['type'], TEvent extends RafPerfEvent & {
+        type: T;
+    }>(type: T, listener: ((e: TEvent) => void) | EventListenerObject | null, options?: boolean | AddEventListenerOptions): void;
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,9 +18,6 @@
         }
       ],
       "license": "MIT",
-      "dependencies": {
-        "events": "^3.3.0"
-      },
       "devDependencies": {
         "canvas-context": "^3.0.1",
         "es-module-shims": "^0.10.3"
@@ -55,14 +52,6 @@
       "resolved": "https://registry.npmjs.org/es-module-shims/-/es-module-shims-0.10.3.tgz",
       "integrity": "sha512-pJ5xMeVtyujSqvjQ9sJw4dIG3eRsWxTcdALk42Xe9V54PFT4tP+cCVLzzWF6jo5BcyMxGc1FKHfosmoaP/PXxQ==",
       "dev": true
-    },
-    "node_modules/events": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
-      "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
-      "engines": {
-        "node": ">=0.8.x"
-      }
     }
   },
   "dependencies": {
@@ -77,11 +66,6 @@
       "resolved": "https://registry.npmjs.org/es-module-shims/-/es-module-shims-0.10.3.tgz",
       "integrity": "sha512-pJ5xMeVtyujSqvjQ9sJw4dIG3eRsWxTcdALk42Xe9V54PFT4tP+cCVLzzWF6jo5BcyMxGc1FKHfosmoaP/PXxQ==",
       "dev": true
-    },
-    "events": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
-      "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q=="
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -33,10 +33,7 @@
   "type": "module",
   "exports": "./index.js",
   "main": "index.js",
-  "types": "types/index.d.ts",
-  "dependencies": {
-    "events": "^3.3.0"
-  },
+  "types": "index.d.ts",
   "devDependencies": {
     "canvas-context": "^3.0.1",
     "es-module-shims": "^0.10.3"


### PR DESCRIPTION
Hi. I thought I'd contribute a bit since I've found your code useful.

I've removed `events` entirely and replaced it with browser native `EventTarget` as per https://github.com/dmnsgn/raf-perf/issues/1#issue-397932237, but my understanding is that you want to support both browser and Node... But, to my understanding, Node doesn't have `requestAnimationFrame`, and it doesn't make much sense to try to create a polyfill for it, and, in case of `node-canvas`, it has been agreed upon that trying to simulate web `requestAnimationFrame` is a no go.

At any rate, feel free to modify or reject this commit if it doesn't fit your vision.